### PR TITLE
Fixes for Portenta

### DIFF
--- a/src/CellularConnectionHandler.cpp
+++ b/src/CellularConnectionHandler.cpp
@@ -26,11 +26,12 @@ CellularConnectionHandler::CellularConnectionHandler()
 
 CellularConnectionHandler::CellularConnectionHandler(const char * pin, const char * apn, const char * login, const char * pass, bool const keep_alive)
 : ConnectionHandler{keep_alive, NetworkAdapter::CELL}
-, _pin(pin)
-, _apn(apn)
-, _login(login)
-, _pass(pass)
 {
+  _settings.type = NetworkAdapter::CELL;
+  strcpy(_settings.cell.pin, pin);
+  strcpy(_settings.cell.apn, apn);
+  strcpy(_settings.cell.login, login);
+  strcpy(_settings.cell.pass, pass);
 
 }
 
@@ -57,7 +58,7 @@ NetworkConnectionState CellularConnectionHandler::update_handleInit()
 {
   _cellular.begin();
   _cellular.setDebugStream(Serial);
-  if (String(_pin).length() > 0 && !_cellular.unlockSIM(_pin)) {
+  if (strlen(_settings.cell.pin) > 0 && !_cellular.unlockSIM(_settings.cell.pin)) {
     Debug.print(DBG_ERROR, F("SIM not present or wrong PIN"));
     return NetworkConnectionState::ERROR;
   }
@@ -66,7 +67,7 @@ NetworkConnectionState CellularConnectionHandler::update_handleInit()
 
 NetworkConnectionState CellularConnectionHandler::update_handleConnecting()
 {
-  if (!_cellular.connect(_apn, _login, _pass)) {
+  if (!_cellular.connect(String(_settings.cell.apn), String(_settings.cell.login), String(_settings.cell.pass))) {
     Debug.print(DBG_ERROR, F("The board was not able to register to the network..."));
     return NetworkConnectionState::ERROR;
   }

--- a/src/CellularConnectionHandler.h
+++ b/src/CellularConnectionHandler.h
@@ -53,11 +53,6 @@ class CellularConnectionHandler : public ConnectionHandler
 
   private:
 
-    const char * _pin;
-    const char * _apn;
-    const char * _login;
-    const char * _pass;
-
     ArduinoCellular _cellular;
     TinyGsmClient _gsm_client = _cellular.getNetworkClient();
 };

--- a/src/ConnectionHandlerInterface.h
+++ b/src/ConnectionHandlerInterface.h
@@ -51,7 +51,7 @@ class ConnectionHandler {
 
     virtual ~ConnectionHandler() {}
 
-    NetworkConnectionState check();
+    virtual NetworkConnectionState check();
 
     #if not defined(BOARD_HAS_LORA)
       virtual unsigned long getTime() = 0;

--- a/src/GenericConnectionHandler.cpp
+++ b/src/GenericConnectionHandler.cpp
@@ -22,11 +22,10 @@
 static inline ConnectionHandler* instantiate_handler(NetworkAdapter adapter);
 
 bool GenericConnectionHandler::updateSetting(const models::NetworkSetting& s) {
-
-    if(_ch != nullptr && _ch->_current_net_connection_state != NetworkConnectionState::INIT) {
+    if(_ch != nullptr && _current_net_connection_state != NetworkConnectionState::INIT) {
         // If the internal connection handler is already being used and not in INIT phase we cannot update the settings
         return false;
-    } else if(_ch != nullptr && _ch->_current_net_connection_state == NetworkConnectionState::INIT && _interface != s.type) {
+    } else if(_ch != nullptr && _current_net_connection_state == NetworkConnectionState::INIT && _interface != s.type) {
         // If the internal connection handler is already being used and in INIT phase and the interface type is being changed
         // -> we need to deallocate the previously allocated handler
 

--- a/src/GenericConnectionHandler.cpp
+++ b/src/GenericConnectionHandler.cpp
@@ -22,10 +22,10 @@
 static inline ConnectionHandler* instantiate_handler(NetworkAdapter adapter);
 
 bool GenericConnectionHandler::updateSetting(const models::NetworkSetting& s) {
-    if(_ch != nullptr && _current_net_connection_state != NetworkConnectionState::INIT) {
+    if(_ch != nullptr && _ch->_current_net_connection_state != NetworkConnectionState::INIT) {
         // If the internal connection handler is already being used and not in INIT phase we cannot update the settings
         return false;
-    } else if(_ch != nullptr && _current_net_connection_state == NetworkConnectionState::INIT && _interface != s.type) {
+    } else if(_ch != nullptr && _ch->_current_net_connection_state == NetworkConnectionState::INIT && _interface != s.type) {
         // If the internal connection handler is already being used and in INIT phase and the interface type is being changed
         // -> we need to deallocate the previously allocated handler
 
@@ -47,6 +47,11 @@ bool GenericConnectionHandler::updateSetting(const models::NetworkSetting& s) {
 
         return false;
     }
+}
+
+NetworkConnectionState GenericConnectionHandler::check()
+{
+    return _ch != nullptr ? _ch->check() : NetworkConnectionState::INIT;
 }
 
 NetworkConnectionState GenericConnectionHandler::update_handleInit() {

--- a/src/GenericConnectionHandler.h
+++ b/src/GenericConnectionHandler.h
@@ -38,6 +38,8 @@ class GenericConnectionHandler : public ConnectionHandler
 
     GenericConnectionHandler(bool const keep_alive=true): ConnectionHandler(keep_alive), _ch(nullptr) {}
 
+    NetworkConnectionState check() override;
+    
     #if defined(BOARD_HAS_NOTECARD) || defined(BOARD_HAS_LORA)
       virtual bool available() = 0;
       virtual int read() = 0;

--- a/src/settings/settings_default.h
+++ b/src/settings/settings_default.h
@@ -51,7 +51,7 @@ namespace models {
     #endif  //defined(BOARD_HAS_CATM1_NBIOT)
 
     #if defined(BOARD_HAS_LORA)
-    case LORA:
+    case NetworkAdapter::LORA:
       res.lora.band = 5; // _lora_band::EU868
       res.lora.channelMask[0] = '\0';
       res.lora.deviceClass = 'A'; // _lora_class::CLASS_A


### PR DESCRIPTION
1. Fix nullptr on Cellular connectivity
2. Fix the rule in checks int the updateSetting since the _ch->_current_net_connection_state is always in INIT state because the _ch->check() is never called